### PR TITLE
fix(codegen): use var for interface-shaped zero values in ?

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -80,17 +80,24 @@ impl Codegen {
         self.error_var_counter = 0;
     }
 
-    /// Generate zero value for a type
-    pub(crate) fn zero_value(&self, ty: &str) -> String {
+    /// Generate zero value for a type.
+    ///
+    /// Returns `Some(expr)` when the zero value can be written from the type name
+    /// alone, and `None` when it cannot. `None` covers named types whose
+    /// underlying shape isn't visible here - enums and interfaces compile to Go
+    /// interfaces (zero value `nil`) while structs need `T{}`, and the name alone
+    /// doesn't distinguish them. Callers must declare a `var` of the type instead
+    /// and let Go compute the zero value.
+    pub(crate) fn zero_value(&self, ty: &str) -> Option<String> {
         match ty {
-            "int" | "int8" | "int16" | "int32" | "int64" => "0".to_string(),
+            "int" | "int8" | "int16" | "int32" | "int64" => Some("0".to_string()),
             "uint" | "uint8" | "uint16" | "uint32" | "uint64" | "uintptr" | "byte" | "rune" => {
-                "0".to_string()
+                Some("0".to_string())
             }
-            "float32" | "float64" => "0".to_string(),
-            "bool" => "false".to_string(),
-            "string" => "\"\"".to_string(),
-            "" | "()" => "".to_string(), // unit type
+            "float32" | "float64" => Some("0".to_string()),
+            "bool" => Some("false".to_string()),
+            "string" => Some("\"\"".to_string()),
+            "" | "()" => Some("".to_string()), // unit type
             _ if ty.starts_with('*')
                 || ty.starts_with("[]")
                 || ty.starts_with("map[")
@@ -99,12 +106,9 @@ impl Codegen {
                 || ty.starts_with("func(") =>
             {
                 // Pointers, slices, maps, channels, error, functions -> nil
-                "nil".to_string()
+                Some("nil".to_string())
             }
-            _ => {
-                // Struct types -> TypeName{}
-                format!("{}{{}}", ty)
-            }
+            _ => None,
         }
     }
 

--- a/src/codegen/stmt.rs
+++ b/src/codegen/stmt.rs
@@ -889,35 +889,49 @@ impl Codegen {
             // Default: return zero values (+ error if function returns error)
             self.emit("{\n");
             self.indent();
-            self.emit_indent();
-            self.emit("return ");
 
             let return_types = self.current_return_types.clone();
             let returns_error = return_types
                 .last()
                 .is_some_and(|ty| ty == "error" || ty.ends_with(".error"));
 
+            // Types needing a zero value: everything except a trailing `error`,
+            // which is filled in with the captured error variable instead.
+            let value_types = if returns_error {
+                &return_types[..return_types.len().saturating_sub(1)]
+            } else {
+                &return_types[..]
+            };
+
+            // Resolve each zero value. Types we can't write directly get a `var`
+            // declaration so Go computes the zero value - this is what makes
+            // interface-shaped returns (enums, interfaces) come out as nil rather
+            // than an illegal `T{}` composite literal.
+            let mut zero_values: Vec<String> = Vec::with_capacity(value_types.len());
+            for (i, ty) in value_types.iter().enumerate() {
+                match self.zero_value(ty) {
+                    Some(expr) => zero_values.push(expr),
+                    None => {
+                        // Scoped to this `if err != nil { ... }` block, so indexing
+                        // by return position is enough to stay unique.
+                        let var = format!("_zero{}", i);
+                        self.emit_indent();
+                        self.emit(format!("var {} {}\n", var, ty));
+                        zero_values.push(var);
+                    }
+                }
+            }
+
+            self.emit_indent();
+            self.emit("return ");
+            self.emit(zero_values.join(", "));
+
             if returns_error {
-                // Generate zero values for all return types except last (error)
-                let zero_values: Vec<String> = return_types
-                    .iter()
-                    .take(return_types.len().saturating_sub(1))
-                    .map(|ty| self.zero_value(ty))
-                    .collect();
-
-                self.emit(zero_values.join(", "));
-
                 // Add error variable
                 if !zero_values.is_empty() {
                     self.emit(", ");
                 }
                 self.emit(&err_var);
-            } else {
-                // No error return - just return zero values for all return types
-                let zero_values: Vec<String> =
-                    return_types.iter().map(|ty| self.zero_value(ty)).collect();
-
-                self.emit(zero_values.join(", "));
             }
             self.emit("\n");
             self.dedent();

--- a/tests/fixtures/single/pass/try_interface_return.sop
+++ b/tests/fixtures/single/pass/try_interface_return.sop
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Enums compile to Go interfaces, so the zero value used by `?` must be nil
+// rather than an illegal `Shape{}` composite literal.
+type Shape enum {
+	Circle struct { radius float64 }
+	Square struct { side float64 }
+}
+
+type Describer interface {
+	Describe() string
+}
+
+type Box struct {
+	label string
+}
+
+func (b Box) Describe() string { return b.label }
+
+func parseShape(s string) (Shape, error) {
+	r := strconv.ParseFloat(s, 64) ?
+	return Shape.Circle{radius: r}, nil
+}
+
+func parseNilableShape(s string) (?Shape, error) {
+	r := strconv.ParseFloat(s, 64) ?
+	return Shape.Square{side: r}, nil
+}
+
+// User-defined Soppo interface as the non-error return.
+func parseDescriber(s string) (Describer, error) {
+	n := strconv.Atoi(s) ?
+	_ = n
+	return Box{label: s}, nil
+}
+
+// Interface coming from a Go package.
+func parseReader(s string) (io.Reader, error) {
+	n := strconv.Atoi(s) ?
+	_ = n
+	return strings.NewReader(s), nil
+}
+
+// Structs keep working - `var x T` has the same zero value as `T{}`.
+func parseBox(s string) (Box, error) {
+	n := strconv.Atoi(s) ?
+	_ = n
+	return Box{label: s}, nil
+}
+
+// Multiple non-error returns mixing an interface with a primitive.
+func parseBoth(s string) (Shape, int, error) {
+	n := strconv.Atoi(s) ?
+	return Shape.Circle{radius: 1.0}, n, nil
+}
+
+func main() {
+	_, _ = parseShape("1.5")
+	_, _ = parseNilableShape("2.5")
+	_, _ = parseDescriber("3")
+	_, _ = parseReader("4")
+	_, _ = parseBox("5")
+	_, _, _ = parseBoth("6")
+}

--- a/tests/snapshots/single__pass__try_interface_return.snap
+++ b/tests/snapshots/single__pass__try_interface_return.snap
@@ -1,0 +1,122 @@
+---
+source: tests/single.rs
+expression: output
+---
+//soppo:generated v1
+package main
+
+import (
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Enums compile to Go interfaces, so the zero value used by `?` must be nil
+// rather than an illegal `Shape{}` composite literal.
+/*soppo:enum
+Shape {
+    Circle {
+        radius float64
+    }
+    Square {
+        side float64
+    }
+}
+*/
+type Shape interface {
+	isShape()
+}
+
+type Shape_Circle struct {
+	radius float64
+}
+func (Shape_Circle) isShape() {}
+
+type Shape_Square struct {
+	side float64
+}
+func (Shape_Square) isShape() {}
+
+
+type Describer interface {
+	Describe() string
+}
+
+type Box struct {
+	label string
+}
+
+func (b Box) Describe() string {
+	return b.label
+}
+
+func parseShape(s string) (Shape, error) {
+	r, _err0 := strconv.ParseFloat(s, 64)
+	if _err0 != nil {
+		var _zero0 Shape
+		return _zero0, _err0
+	}
+	return Shape_Circle{radius: r}, nil
+}
+
+//soppo:nilable : 0
+func parseNilableShape(s string) (Shape, error) {
+	r, _err0 := strconv.ParseFloat(s, 64)
+	if _err0 != nil {
+		var _zero0 Shape
+		return _zero0, _err0
+	}
+	return Shape_Square{side: r}, nil
+}
+
+// User-defined Soppo interface as the non-error return.
+func parseDescriber(s string) (Describer, error) {
+	n, _err0 := strconv.Atoi(s)
+	if _err0 != nil {
+		var _zero0 Describer
+		return _zero0, _err0
+	}
+	_ = n
+	return Box{label: s}, nil
+}
+
+// Interface coming from a Go package.
+func parseReader(s string) (io.Reader, error) {
+	n, _err0 := strconv.Atoi(s)
+	if _err0 != nil {
+		var _zero0 io.Reader
+		return _zero0, _err0
+	}
+	_ = n
+	return strings.NewReader(s), nil
+}
+
+// Structs keep working - `var x T` has the same zero value as `T{}`.
+func parseBox(s string) (Box, error) {
+	n, _err0 := strconv.Atoi(s)
+	if _err0 != nil {
+		var _zero0 Box
+		return _zero0, _err0
+	}
+	_ = n
+	return Box{label: s}, nil
+}
+
+// Multiple non-error returns mixing an interface with a primitive.
+func parseBoth(s string) (Shape, int, error) {
+	n, _err0 := strconv.Atoi(s)
+	if _err0 != nil {
+		var _zero0 Shape
+		return _zero0, 0, _err0
+	}
+	return Shape_Circle{radius: 1.0}, n, nil
+}
+
+func main() {
+	_, _ = parseShape("1.5")
+	_, _ = parseNilableShape("2.5")
+	_, _ = parseDescriber("3")
+	_, _ = parseReader("4")
+	_, _ = parseBox("5")
+	_, _, _ = parseBoth("6")
+}

--- a/tests/snapshots/single__pass__try_operator.snap
+++ b/tests/snapshots/single__pass__try_operator.snap
@@ -216,7 +216,8 @@ func tryWithStringReturn() (string, error) {
 func tryWithStructReturn() (User, error) {
 	user, _err0 := getUser(1)
 	if _err0 != nil {
-		return User{}, _err0
+		var _zero0 User
+		return _zero0, _err0
 	}
 	return (*user), nil
 }


### PR DESCRIPTION
Fixes #52.

## Root cause

`zero_value` in `src/codegen/mod.rs` receives only the type *name*:

```rust
_ if ty.starts_with('*') || ty.starts_with("[]") || ty == "error" || ... => "nil",
_ => format!("{}{{}}", ty),   // everything else
```

Enums compile to a sealed Go interface (`type Shape interface { isShape() }`), so `Shape` lands in the final arm and `?` emits an illegal composite literal. The contrast shows up inside a single generated function:

```go
return nil, fmt.Errorf("circle needs 1 argument (radius)")   // explicit return: fine
return Shape{}, _err0                                        // ? desugaring: invalid
```

## Scope is wider than the issue

A type name can't distinguish interface from struct, so every interface-shaped non-error return was affected:

| non-error return type | was emitted | valid Go? |
| --- | --- | --- |
| Soppo enum (`Shape`) | `Shape{}` | no |
| Soppo `interface` (`Describer`) | `Describer{}` | no |
| Go package interface (`io.Reader`) | `io.Reader{}` | no |
| plain struct (`Box`) | `Box{}` | yes |

## Approach

Classifying the type inside codegen isn't possible — there's no Go package cache there, so `io.Reader` (interface) can't be told apart from `strings.Builder` (struct). So rather than classify, let Go compute the zero value: `var x T` is correct for every `T`.

`zero_value` now returns `None` when the name alone isn't enough, and the caller declares a `var`:

```go
r, _err0 := strconv.ParseFloat(values[0], 64)
if _err0 != nil {
    var _zero0 Shape
    return _zero0, _err0
}
```

Names that were already unambiguous keep the literal path, so **generated output is unchanged everywhere else**. Across the whole snapshot suite exactly one line moves — `try_operator.snap`, where the return type is a struct, so `var _zero0 User` is semantically identical to `User{}`.

## Verification

The reporter's shape-calculator now builds and runs, error paths included:

```
$ go build -o /dev/null ./gen     # was 5x "invalid composite literal type Shape"
$ go run ./gen
=== 直接计算 ===
面积: 78.54
=== 从字符串解析（含错误处理） ===
解析成功！circle 的面积是: 78.54
解析失败: strconv.ParseFloat: parsing "abc": invalid syntax
解析失败: unknown shape type: hexagon
```

Added `tests/fixtures/single/pass/try_interface_return.sop`, covering enum / nilable enum / Soppo interface / Go interface / struct / interface-mixed-with-primitive returns. `tests/single.rs` runs `go vet` on generated output, so a fixture like this would have caught the bug; reverting the codegen change makes it fail:

```
vet: ./try_interface_return.go:52:10: invalid composite literal type Shape
```

`cargo test --workspace` — 115 passed. `cargo +nightly fmt --all -- --check` — clean.

## Note on CI

The Clippy job will fail on this PR, but not because of this change — `cargo clippy -- -D warnings` already fails on `main` (`src/types/infer/pat.rs:60` and `:193`). Clippy output on this branch contains those two errors and nothing else. #54 fixes them; happy to rebase this on top of that, or fold the two together, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)