### PR TITLE
chore: fix clippy unneeded_wildcard_pattern

### DIFF
--- a/src/types/infer/pat.rs
+++ b/src/types/infer/pat.rs
@@ -54,12 +54,7 @@ impl Infer {
                 self.insert_var(binding.name.clone(), binding_ty, Some(binding.span))?;
                 Ok(())
             }
-            PatternKind::StructDestructor {
-                name,
-                fields,
-                rest: _,
-                ..
-            } => {
+            PatternKind::StructDestructor { name, fields, .. } => {
                 // For struct destructor patterns like Circle{radius: r, ...} or Point{x: 0, y}
                 let variant_name = name.rsplit('.').next().unwrap_or(name);
 
@@ -187,12 +182,7 @@ impl Infer {
 
                 bindings.insert(binding.name.clone(), binding_ty);
             }
-            PatternKind::StructDestructor {
-                name,
-                fields,
-                rest: _,
-                ..
-            } => {
+            PatternKind::StructDestructor { name, fields, .. } => {
                 let variant_name = name.rsplit('.').next().unwrap_or(name);
 
                 if let Type::Con { sym: type_name, .. } = scrutinee_ty


### PR DESCRIPTION
`cargo clippy --workspace --tests -- -D warnings` currently fails on `main`, which has kept the Clippy job red since c063b89:

```
error: this pattern is unneeded as the `..` pattern can match that element
  --> src/types/infer/pat.rs:60:17
  --> src/types/infer/pat.rs:193:17
error: could not compile `soppo` (lib) due to 2 previous errors
```

`rest: _` is redundant next to `..`, so this just drops it. Removing the field lets both patterns collapse onto one line, which is what `cargo +nightly fmt` then wants — that formatting is included.

### Why this might be worth taking first

`release-plz-pr` and `release-plz-release` both declare `needs: [test, clippy, fmt]`, so while Clippy is red they are skipped on every push to `main` — visible in the job list of the last run on main:

```
X Clippy
✓ Tests    ✓ Format
- Release-plz release      (skipped)
- Release-plz PR           (skipped)
```

So the release pipeline is currently blocked as well.

### Verification

Run locally on aarch64-apple-darwin, rustc 1.97.1 stable / 1.99.0-nightly:

- `cargo clippy --workspace --tests -- -D warnings` — passes
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test --workspace` — 114 passed

One test, `fail__switch`, fails locally but is unrelated to this change and also fails on unmodified `main`. `miette` emits OSC 8 hyperlink escapes for the one diagnostic carrying `url(...)`, and `tests/single.rs` snapshots stderr without passing it through `sanitise_error`, so the stored plain-text snapshot only matches in environments where hyperlinks are off (such as CI). Setting `FORCE_HYPERLINK=0` suppresses it. Happy to open a separate PR for that if you'd like it made hermetic.

Message prefixed `chore:` so release-plz keeps it out of the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
